### PR TITLE
made clip error message more informative

### DIFF
--- a/fishEntry.R
+++ b/fishEntry.R
@@ -446,7 +446,7 @@ updateFish<-function(headerRows=18,dbdir="~/Documents/Research/MFE/database/",db
         if(any(!unique(clipRecap)%in%c(fishInfoDB$clipApply[grepl(lakeID,fishInfoDB$sampleID)],fishInfoIS$clipApply[grepl(lakeID,fishInfoIS$sampleID)]))){
           
           if(force_clip==FALSE){
-            stop("You have indicated a clipApply or clipRecapture that is not in the database or in-season database. If you are certain this is the correct clipApply or clipRecapture then use the argument force_clip.")
+            stop(paste("You have indicated a clipApply or clipRecapture that is not in the database or in-season database.",lakeID, ". If you are certain this is the correct clipApply or clipRecapture then use the argument force_clip."))
           }
         }
       }


### PR DESCRIPTION
there are two kinds of clip checks, one that checks the clip type is in the database and one that checks the clip type has been seen in that lake before. I change the error message for the lake:clip check to tell you that the clip hasn't been recorded in that lake before. Previously both error messages were the same so it was hard to tell what the problem was.